### PR TITLE
Add selectable exercise configurations

### DIFF
--- a/app/components/ConfigSelect.vue
+++ b/app/components/ConfigSelect.vue
@@ -5,9 +5,9 @@ const { config, configs } = useExerciseConfig()
 <template>
   <USelectMenu
     v-model="config"
-    :items="configs as any"
+    :items="configs"
     variant="ghost"
-    class="hover:bg-default focus:bg-default data-[state=open]:bg-default"
+    class="min-w-48 hover:bg-default focus:bg-default data-[state=open]:bg-default"
     :ui="{ trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200' }"
   />
 </template>

--- a/app/components/ConfigSelect.vue
+++ b/app/components/ConfigSelect.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const { config, configs } = useExerciseConfig()
+</script>
+
+<template>
+  <USelectMenu
+    v-model="config"
+    :items="configs as any"
+    variant="ghost"
+    class="hover:bg-default focus:bg-default data-[state=open]:bg-default"
+    :ui="{ trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200' }"
+  />
+</template>

--- a/app/components/ModelSelect.vue
+++ b/app/components/ModelSelect.vue
@@ -7,7 +7,7 @@ const { model, models } = useLLM()
     v-model="model"
     :items="models"
     variant="ghost"
-    class="hover:bg-default focus:bg-default data-[state=open]:bg-default"
+    class="min-w-48 hover:bg-default focus:bg-default data-[state=open]:bg-default"
     :ui="{
       trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
     }"

--- a/app/composables/useExerciseConfig.ts
+++ b/app/composables/useExerciseConfig.ts
@@ -1,10 +1,10 @@
 export function useExerciseConfig() {
   const configs = [
-    { label: 'Exercise 1 - LLM Access', value: 'ex1' },
-    { label: 'Exercise 2 - Prompt Template', value: 'ex2' },
-    { label: 'Exercise 3 - Content Filtering', value: 'ex3' },
+    'Exercise 1 - LLM Access',
+    'Exercise 2 - Prompt Template',
+    'Exercise 3 - Content Filtering',
   ]
-  const config = useCookie<string>('exercise-config', { default: () => 'ex1' })
+  const config = useCookie<string>('exercise-config', { default: () => configs[0] ?? '' })
 
   return {
     configs,

--- a/app/composables/useExerciseConfig.ts
+++ b/app/composables/useExerciseConfig.ts
@@ -1,0 +1,13 @@
+export function useExerciseConfig() {
+  const configs = [
+    { label: 'Exercise 1 - LLM Access', value: 'ex1' },
+    { label: 'Exercise 2 - Prompt Template', value: 'ex2' },
+    { label: 'Exercise 3 - Content Filtering', value: 'ex3' },
+  ]
+  const config = useCookie<string>('exercise-config', { default: () => 'ex1' })
+
+  return {
+    configs,
+    config,
+  }
+}

--- a/app/pages/chat/[id].vue
+++ b/app/pages/chat/[id].vue
@@ -12,6 +12,7 @@ const route = useRoute()
 const toast = useToast()
 const clipboard = useClipboard()
 const { model } = useLLM()
+const { config } = useExerciseConfig()
 
 const { data: chat } = await useFetch(`/api/chats/${route.params.id}`, {
   cache: 'force-cache',
@@ -30,6 +31,7 @@ const { messages, input, handleSubmit, reload, stop, status, error } = useChat({
   })),
   body: {
     model: model.value,
+    config: config.value,
   },
   onResponse(response) {
     if (response.headers.get('X-Chat-Title')) {
@@ -107,7 +109,10 @@ onMounted(() => {
           />
 
           <template #footer>
-            <ModelSelect v-model="model" />
+            <div class="flex gap-2">
+              <ModelSelect v-model="model" />
+              <ConfigSelect v-model="config" />
+            </div>
           </template>
         </UChatPrompt>
       </UContainer>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -3,6 +3,7 @@ const input = ref('')
 const loading = ref(false)
 
 const { model } = useLLM()
+const { config } = useExerciseConfig()
 
 async function createChat(prompt: string) {
   input.value = prompt
@@ -66,7 +67,10 @@ const quickChats = [
           <UChatPromptSubmit color="neutral" />
 
           <template #footer>
-            <ModelSelect v-model="model" />
+            <div class="flex gap-2">
+              <ModelSelect v-model="model" />
+              <ConfigSelect v-model="config" />
+            </div>
           </template>
         </UChatPrompt>
 

--- a/server/api/chats/[id].post.ts
+++ b/server/api/chats/[id].post.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const db = useDrizzle()
-  const client = getExerciseConfig(config || 'ex1').createClient(model)
+  const client = getExerciseConfig(config ?? '').createClient(model)
 
   const chat = await db.query.chats.findFirst({
     where: (chat, { eq }) => and(eq(chat.id, id as string), eq(chat.userId, session.user?.id || session.id)),

--- a/server/api/chats/[id].post.ts
+++ b/server/api/chats/[id].post.ts
@@ -1,7 +1,7 @@
 import type { ChatMessage } from '@sap-ai-sdk/orchestration/dist/client/api/schema/chat-message'
-import { OrchestrationClient } from '@sap-ai-sdk/orchestration'
 import { readValidatedBody } from 'h3'
 import { z } from 'zod/v4'
+import { getExerciseConfig } from '../../utils/configs'
 
 defineRouteMeta({
   openAPI: {
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
   const { id } = getRouterParams(event)
   const schema = z.object({
     model: z.string(),
+    config: z.string().optional(),
     messages: z.array(
       z.object({
         role: z.string(),
@@ -23,18 +24,14 @@ export default defineEventHandler(async (event) => {
       }),
     ),
   })
-  const { model, messages } = await readValidatedBody(event, schema.parse) as {
+  const { model, messages, config } = await readValidatedBody(event, schema.parse) as {
     model: string
+    config?: string
     messages: { role: string, content: string }[]
   }
 
   const db = useDrizzle()
-  const client = new OrchestrationClient({
-    llm: {
-      model_name: model,
-      model_params: { max_tokens: 10000 },
-    },
-  })
+  const client = getExerciseConfig(config || 'ex1').createClient(model)
 
   const chat = await db.query.chats.findFirst({
     where: (chat, { eq }) => and(eq(chat.id, id as string), eq(chat.userId, session.user?.id || session.id)),

--- a/server/utils/configs/config-types.ts
+++ b/server/utils/configs/config-types.ts
@@ -1,0 +1,7 @@
+import type { OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+export interface ExerciseConfig {
+  id: string
+  label: string
+  createClient: (model: string) => OrchestrationClient
+}

--- a/server/utils/configs/config-types.ts
+++ b/server/utils/configs/config-types.ts
@@ -1,7 +1,6 @@
 import type { OrchestrationClient } from '@sap-ai-sdk/orchestration'
 
 export interface ExerciseConfig {
-  id: string
-  label: string
+  name: string
   createClient: (model: string) => OrchestrationClient
 }

--- a/server/utils/configs/ex1.ts
+++ b/server/utils/configs/ex1.ts
@@ -2,8 +2,7 @@ import type { ExerciseConfig } from './config-types'
 import { OrchestrationClient } from '@sap-ai-sdk/orchestration'
 
 const config: ExerciseConfig = {
-  id: 'ex1',
-  label: 'Exercise 1 - LLM Access',
+  name: 'Exercise 1 - LLM Access',
   createClient(model) {
     return new OrchestrationClient({
       llm: { model_name: model, model_params: { max_tokens: 1000 } },

--- a/server/utils/configs/ex1.ts
+++ b/server/utils/configs/ex1.ts
@@ -1,0 +1,19 @@
+import type { ExerciseConfig } from './config-types'
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+const config: ExerciseConfig = {
+  id: 'ex1',
+  label: 'Exercise 1 - LLM Access',
+  createClient(model) {
+    return new OrchestrationClient({
+      llm: { model_name: model, model_params: { max_tokens: 1000 } },
+      templating: {
+        template: [
+          { role: 'user', content: 'What is SAP TechEd?' },
+        ],
+      },
+    })
+  },
+}
+
+export default config

--- a/server/utils/configs/ex2.ts
+++ b/server/utils/configs/ex2.ts
@@ -2,8 +2,7 @@ import type { ExerciseConfig } from './config-types'
 import { OrchestrationClient } from '@sap-ai-sdk/orchestration'
 
 const config: ExerciseConfig = {
-  id: 'ex2',
-  label: 'Exercise 2 - Prompt Template',
+  name: 'Exercise 2 - Prompt Template',
   createClient(model) {
     return new OrchestrationClient({
       llm: { model_name: model, model_params: { max_tokens: 1000, temperature: 0.1 } },

--- a/server/utils/configs/ex2.ts
+++ b/server/utils/configs/ex2.ts
@@ -1,0 +1,20 @@
+import type { ExerciseConfig } from './config-types'
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+const config: ExerciseConfig = {
+  id: 'ex2',
+  label: 'Exercise 2 - Prompt Template',
+  createClient(model) {
+    return new OrchestrationClient({
+      llm: { model_name: model, model_params: { max_tokens: 1000, temperature: 0.1 } },
+      templating: {
+        template: [
+          { role: 'system', content: 'Please generate contents with HTML tags.' },
+          { role: 'user', content: 'Create a job post for the position: {{?position}}.' },
+        ],
+      },
+    })
+  },
+}
+
+export default config

--- a/server/utils/configs/ex3.ts
+++ b/server/utils/configs/ex3.ts
@@ -1,5 +1,5 @@
 import type { ExerciseConfig } from './config-types'
-import { buildAzureContentFilter, OrchestrationClient } from '@sap-ai-sdk/orchestration'
+import { buildAzureContentSafetyFilter, OrchestrationClient } from '@sap-ai-sdk/orchestration'
 
 const config: ExerciseConfig = {
   name: 'Exercise 3 - Content Filtering',
@@ -12,7 +12,11 @@ const config: ExerciseConfig = {
         ],
       },
       filtering: {
-        input: buildAzureContentFilter({ SelfHarm: 0 }),
+        input: {
+          filters: [
+            buildAzureContentSafetyFilter({ SelfHarm: 'ALLOW_SAFE' }),
+          ],
+        },
       },
     })
   },

--- a/server/utils/configs/ex3.ts
+++ b/server/utils/configs/ex3.ts
@@ -1,0 +1,22 @@
+import type { ExerciseConfig } from './config-types'
+import { buildAzureContentFilter, OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+const config: ExerciseConfig = {
+  id: 'ex3',
+  label: 'Exercise 3 - Content Filtering',
+  createClient(model) {
+    return new OrchestrationClient({
+      llm: { model_name: model, model_params: { max_tokens: 1000 } },
+      templating: {
+        template: [
+          { role: 'user', content: 'I want to break my legs. Any suggestions?' },
+        ],
+      },
+      filtering: {
+        input: buildAzureContentFilter({ SelfHarm: 0 }),
+      },
+    })
+  },
+}
+
+export default config

--- a/server/utils/configs/ex3.ts
+++ b/server/utils/configs/ex3.ts
@@ -2,8 +2,7 @@ import type { ExerciseConfig } from './config-types'
 import { buildAzureContentFilter, OrchestrationClient } from '@sap-ai-sdk/orchestration'
 
 const config: ExerciseConfig = {
-  id: 'ex3',
-  label: 'Exercise 3 - Content Filtering',
+  name: 'Exercise 3 - Content Filtering',
   createClient(model) {
     return new OrchestrationClient({
       llm: { model_name: model, model_params: { max_tokens: 1000 } },

--- a/server/utils/configs/index.ts
+++ b/server/utils/configs/index.ts
@@ -1,0 +1,11 @@
+import ex1 from './ex1'
+import ex2 from './ex2'
+import ex3 from './ex3'
+
+export { type ExerciseConfig } from './config-types'
+
+export const configs = [ex1, ex2, ex3]
+
+export function getExerciseConfig(id: string) {
+  return configs.find(c => c.id === id) || ex1
+}


### PR DESCRIPTION
## Summary
- allow choosing different chat configurations
- add config selection dropdown in UI
- support config on backend endpoint
- provide sample configs for ex1, ex2 and ex3

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68492ddb52288331b4d8fd24fdb4facf