### PR TITLE
Add data masking and chatbot exercises

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,12 +1,45 @@
 # JavaScript Exercises
 
-These hands-on tasks demonstrate features of the SAP Cloud SDK for AI. They assume you already learned the basics of the SDK and its orchestration capabilities earlier in the course.
+These hands-on tasks demonstrate the orchestration features of the SAP Cloud SDK for AI. Orchestration harmonizes multiple generative AI models through a unified client and offers powerful modules to enhance your prompts and responses:
 
-- [Exercise 0](./ex0/README.md) – Preparation and API overview
-- [Exercise 1](./ex1/README.md) – Getting LLM Access via Orchestration Service
-- [Exercise 2](./ex2/README.md) – Prompt Templating
-- [Exercise 3](./ex3/README.md) – Content Filtering
-- [Exercise 4](./ex4/README.md) – Data Masking
-- [Exercise 5](./ex5/README.md) – Orchestration Chatbot
+- **LLM Configuration** – Choose your model, version and custom parameters.  
+  See [LLM Configuration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#llm-configuration)
+- **Harmonized API** – Swap between foundation models without code changes.  
+  See [Harmonized API](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#harmonized-api)
+- **Templating** – Define static or dynamic prompts, use placeholders, reference central templates or local YAML files.  
+  See [Templating](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#templating), [Prompt Registry](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#prompt-registry), [Local Prompt Template](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#local-prompt-template)
+- **Function Calling** – Enable multi-step workflows by letting the model invoke your functions (tools).  
+  See [Function Calling](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#function-calling)
+- **Response Format** – Enforce structured outputs using JSON Schema or Zod.  
+  See [Response Format](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#response-format)
+- **Message History** – Maintain conversation context across requests.  
+  See [Message History](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#message-history)
+- **Image Recognition** – Send images as part of user messages and get multimodal responses.  
+  See [Image Recognition](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#image-recognition)
+- **Content Filtering** – Safeguard both input and output with Azure or Llama Guard filters.  
+  See [Content Filtering](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#content-filtering), [Azure Content Filter](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#azure-content-filter), [Llama Guard Filter](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#llama-guard-filter)
+- **Data Masking** – Mask sensitive data in prompts, with optional SAP Data Privacy integration.  
+  See [Data Masking](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#data-masking), [SAP Data Privacy Integration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#sap-data-privacy-integration)
+- **Grounding** – Inject external or domain-specific data (e.g. documents, vectors) into your prompts.  
+  See [Grounding](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#grounding)
+- **Translation** – Automatically translate input and output via SAP’s Document Translation.  
+  See [Translation](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#translation)
+- **JSON Configuration** – Load entire workflows from AI Launchpad JSON exports.  
+  See [Use JSON Configuration from AI Launchpad](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#use-json-configuration-from-ai-launchpad)
+- **Streaming** – Stream real-time responses, delta content, tool-calls, and control via AbortController.  
+  See [Streaming](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#streaming)
+- **Advanced Deployment Options** – Customize resource groups, request headers, or destinations.  
+  See [Custom Resource Group](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-resource-group), [Custom Request Configuration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-request-configuration), [Custom Destination](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-destination)
 
-For more details about the SDK, see the [official documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js). The orchestration chat completion API is described [here](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion).
+---
+
+## Exercises
+
+- [Exercise 0](./ex0/README.md) – Preparation and API overview  
+- [Exercise 1](./ex1/README.md) – Getting LLM Access via Orchestration Service  
+- [Exercise 2](./ex2/README.md) – Prompt Templating  
+- [Exercise 3](./ex3/README.md) – Content Filtering  
+- [Exercise 4](./ex4/README.md) – Data Masking  
+- [Exercise 5](./ex5/README.md) – Orchestration Chatbot  
+
+For full details, see the [official JS overview](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js) and the [orchestration chat completion docs](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion).

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,10 +1,12 @@
 # JavaScript Exercises
 
-These hands-on tasks demonstrate features of the SAP Cloud SDK for AI.
+These hands-on tasks demonstrate features of the SAP Cloud SDK for AI. They assume you already learned the basics of the SDK and its orchestration capabilities earlier in the course.
 
 - [Exercise 0](./ex0/README.md) – Preparation and API overview
 - [Exercise 1](./ex1/README.md) – Getting LLM Access via Orchestration Service
 - [Exercise 2](./ex2/README.md) – Prompt Templating
 - [Exercise 3](./ex3/README.md) – Content Filtering
+- [Exercise 4](./ex4/README.md) – Data Masking
+- [Exercise 5](./ex5/README.md) – Orchestration Chatbot
 
-For more details about the SDK, see the [official documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js).
+For more details about the SDK, see the [official documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js). The orchestration chat completion API is described [here](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion).

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -2,44 +2,44 @@
 
 These hands-on tasks demonstrate the orchestration features of the SAP Cloud SDK for AI. Orchestration harmonizes multiple generative AI models through a unified client and offers powerful modules to enhance your prompts and responses:
 
-- **LLM Configuration** – Choose your model, version and custom parameters.  
+- **LLM Configuration** – Choose your model, version and custom parameters.
   See [LLM Configuration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#llm-configuration)
-- **Harmonized API** – Swap between foundation models without code changes.  
+- **Harmonized API** – Swap between foundation models without code changes.
   See [Harmonized API](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#harmonized-api)
-- **Templating** – Define static or dynamic prompts, use placeholders, reference central templates or local YAML files.  
+- **Templating** – Define static or dynamic prompts, use placeholders, reference central templates or local YAML files.
   See [Templating](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#templating), [Prompt Registry](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#prompt-registry), [Local Prompt Template](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#local-prompt-template)
-- **Function Calling** – Enable multi-step workflows by letting the model invoke your functions (tools).  
+- **Function Calling** – Enable multi-step workflows by letting the model invoke your functions (tools).
   See [Function Calling](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#function-calling)
-- **Response Format** – Enforce structured outputs using JSON Schema or Zod.  
+- **Response Format** – Enforce structured outputs using JSON Schema or Zod.
   See [Response Format](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#response-format)
-- **Message History** – Maintain conversation context across requests.  
+- **Message History** – Maintain conversation context across requests.
   See [Message History](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#message-history)
-- **Image Recognition** – Send images as part of user messages and get multimodal responses.  
+- **Image Recognition** – Send images as part of user messages and get multimodal responses.
   See [Image Recognition](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#image-recognition)
-- **Content Filtering** – Safeguard both input and output with Azure or Llama Guard filters.  
+- **Content Filtering** – Safeguard both input and output with Azure or Llama Guard filters.
   See [Content Filtering](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#content-filtering), [Azure Content Filter](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#azure-content-filter), [Llama Guard Filter](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#llama-guard-filter)
-- **Data Masking** – Mask sensitive data in prompts, with optional SAP Data Privacy integration.  
+- **Data Masking** – Mask sensitive data in prompts, with optional SAP Data Privacy integration.
   See [Data Masking](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#data-masking), [SAP Data Privacy Integration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#sap-data-privacy-integration)
-- **Grounding** – Inject external or domain-specific data (e.g. documents, vectors) into your prompts.  
+- **Grounding** – Inject external or domain-specific data (e.g. documents, vectors) into your prompts.
   See [Grounding](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#grounding)
-- **Translation** – Automatically translate input and output via SAP’s Document Translation.  
+- **Translation** – Automatically translate input and output via SAP’s Document Translation.
   See [Translation](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#translation)
-- **JSON Configuration** – Load entire workflows from AI Launchpad JSON exports.  
+- **JSON Configuration** – Load entire workflows from AI Launchpad JSON exports.
   See [Use JSON Configuration from AI Launchpad](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#use-json-configuration-from-ai-launchpad)
-- **Streaming** – Stream real-time responses, delta content, tool-calls, and control via AbortController.  
+- **Streaming** – Stream real-time responses, delta content, tool-calls, and control via AbortController.
   See [Streaming](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#streaming)
-- **Advanced Deployment Options** – Customize resource groups, request headers, or destinations.  
+- **Advanced Deployment Options** – Customize resource groups, request headers, or destinations.
   See [Custom Resource Group](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-resource-group), [Custom Request Configuration](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-request-configuration), [Custom Destination](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#custom-destination)
 
 ---
 
 ## Exercises
 
-- [Exercise 0](./ex0/README.md) – Preparation and API overview  
-- [Exercise 1](./ex1/README.md) – Getting LLM Access via Orchestration Service  
-- [Exercise 2](./ex2/README.md) – Prompt Templating  
-- [Exercise 3](./ex3/README.md) – Content Filtering  
-- [Exercise 4](./ex4/README.md) – Data Masking  
-- [Exercise 5](./ex5/README.md) – Orchestration Chatbot  
+- [Exercise 0](./ex0/README.md) – Preparation and API overview
+- [Exercise 1](./ex1/README.md) – Getting LLM Access via Orchestration Service
+- [Exercise 2](./ex2/README.md) – Prompt Templating
+- [Exercise 3](./ex3/README.md) – Content Filtering
+- [Exercise 4](./ex4/README.md) – Data Masking
+- [Exercise 5](./ex5/README.md) – Orchestration Chatbot
 
 For full details, see the [official JS overview](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js) and the [orchestration chat completion docs](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion).

--- a/exercises/ex0/README.md
+++ b/exercises/ex0/README.md
@@ -52,8 +52,4 @@ Open [`server/api/chats/[id].post.ts`](../../server/api/chats/%5Bid%5D.post.ts).
 
 Having this context will help you understand how the configurations from the following exercises are used when chatting.
 
-## Practical Example
-
-IT administrators can use these setup steps to spin up a secure internal prototype before exposing any AI features to a wider audience.
-
 Continue to [Exercise 1 - Getting LLM Access](../ex1/README.md).

--- a/exercises/ex0/README.md
+++ b/exercises/ex0/README.md
@@ -52,4 +52,8 @@ Open [`server/api/chats/[id].post.ts`](../../server/api/chats/%5Bid%5D.post.ts).
 
 Having this context will help you understand how the configurations from the following exercises are used when chatting.
 
+## Practical Example
+
+IT administrators can use these setup steps to spin up a secure internal prototype before exposing any AI features to a wider audience.
+
 Continue to [Exercise 1 - Getting LLM Access](../ex1/README.md).

--- a/exercises/ex1/README.md
+++ b/exercises/ex1/README.md
@@ -31,4 +31,8 @@ Save the file. Nuxt automatically reloads your changes. Trigger the task through
 
 Learn more about orchestrating LLMs in the [documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js).
 
+## Practical Example
+
+A marketing department might set up this minimal configuration to quickly query a foundation model for campaign ideas. Using the orchestration service keeps API keys out of the client application.
+
 Continue to [Exercise 2 - Prompt Templating](../ex2/README.md).

--- a/exercises/ex2/README.md
+++ b/exercises/ex2/README.md
@@ -32,4 +32,8 @@ Save the file and test the task from the chat page. The LLM should generate a sh
 
 Learn more about prompt templating in the [documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js).
 
+## Practical Example
+
+Recruiters can use this template to consistently create job adverts by only supplying the job title. The HTML formatting ensures the output integrates nicely with web portals.
+
 Continue to [Exercise 3 - Content Filtering](../ex3/README.md).

--- a/exercises/ex3/README.md
+++ b/exercises/ex3/README.md
@@ -37,3 +37,7 @@ Call `chatCompletion` and handle any errors if the filter blocks the prompt.
 Save the file and invoke the task. Unsafe input should be rejected according to the filter rules.
 
 Explore content filtering in the [documentation](https://sap.github.io/ai-sdk/docs/js/overview-cloud-sdk-for-ai-js).
+
+## Practical Example
+
+Compliance teams can integrate this filter to automatically reject self-harm or violent prompts before they are sent to the LLM, reducing the risk of inappropriate content in corporate chatbots.

--- a/exercises/ex4/README.md
+++ b/exercises/ex4/README.md
@@ -1,0 +1,45 @@
+# Exercise 4 - Data Masking
+
+This exercise demonstrates how to mask personal data before passing it to the LLM.
+
+### 1. Navigate to the Task
+
+Open [`server/tasks/config/ex4.ts`](../../server/tasks/config/ex4.ts).
+
+### 2. Add Implementation
+
+Ensure the task contains the following code:
+
+```typescript
+const model_name = payload.model as string & ChatModel
+const result = new OrchestrationClient({
+  llm: { model_name, model_params: { max_tokens: 1000 } },
+  templating: {
+    template: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'Please repeat the following input: {{?pii}}' },
+    ],
+  },
+  masking: {
+    masking_providers: [
+      buildDpiMaskingProvider({
+        method: 'anonymization',
+        entities: ['profile-person', 'profile-org'],
+      }),
+    ],
+  },
+})
+return { result }
+```
+
+Pass a `pii` input parameter when calling `chatCompletion`.
+
+### 3. Run and Verify
+
+Save the file and test the task from the chat page. The model should receive a masked version of the provided personal data.
+
+Learn more about masking options in the [documentation](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion#data-masking).
+
+## Practical Example
+
+A human resources team could use this task to remove employee names and phone numbers from onboarding questions before sending them to an LLM. This ensures no personal data leaves the company's boundaries.

--- a/exercises/ex5/README.md
+++ b/exercises/ex5/README.md
@@ -1,0 +1,49 @@
+# Exercise 5 - Orchestration Chatbot
+
+This task combines templating, content filtering and data masking to create a safer chatbot configuration.
+
+### 1. Navigate to the Task
+
+Open [`server/tasks/config/ex5.ts`](../../server/tasks/config/ex5.ts).
+
+### 2. Add Implementation
+
+Add the following code to the task:
+
+```typescript
+const model_name = payload.model as string & ChatModel
+const result = new OrchestrationClient({
+  llm: { model_name, model_params: { max_tokens: 1000, temperature: 0.2 } },
+  templating: {
+    template: [
+      { role: 'system', content: 'You are a helpful chatbot assistant.' },
+      { role: 'user', content: '{{?user_query}}' },
+    ],
+  },
+  filtering: {
+    input: { filters: [buildAzureContentSafetyFilter()] },
+    output: { filters: [buildAzureContentSafetyFilter()] },
+  },
+  masking: {
+    masking_providers: [
+      buildDpiMaskingProvider({
+        method: 'anonymization',
+        entities: ['profile-person', 'profile-org'],
+      }),
+    ],
+  },
+})
+return { result }
+```
+
+The existing chat page already stores the conversation history. Use this configuration to stream responses while applying the filters and masking provider.
+
+### 3. Run and Verify
+
+Start a chat using this task. You can send multiple messages and observe that unsafe content is blocked and personal data is masked.
+
+Further reading: [Chat Completion](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion).
+
+## Practical Example
+
+A customer service portal might integrate this chatbot configuration to mask any personal references from support messages and filter offensive language before forwarding the conversation to an external AI provider.

--- a/server/tasks/config/ex4.ts
+++ b/server/tasks/config/ex4.ts
@@ -1,0 +1,29 @@
+import { buildDpiMaskingProvider, type ChatModel, OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+export default defineTask({
+  meta: {
+    name: 'config:ex4',
+    description: 'Exercise 4 - Data Masking',
+  },
+  run({ payload }) {
+    const model_name = payload.model as string & ChatModel
+    const result = new OrchestrationClient({
+      llm: { model_name, model_params: { max_tokens: 1000 } },
+      templating: {
+        template: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'Please repeat the following input: {{?pii}}' },
+        ],
+      },
+      masking: {
+        masking_providers: [
+          buildDpiMaskingProvider({
+            method: 'anonymization',
+            entities: ['profile-person', 'profile-org'],
+          }),
+        ],
+      },
+    })
+    return { result }
+  },
+})

--- a/server/tasks/config/ex5.ts
+++ b/server/tasks/config/ex5.ts
@@ -1,0 +1,33 @@
+import { buildAzureContentSafetyFilter, buildDpiMaskingProvider, type ChatModel, OrchestrationClient } from '@sap-ai-sdk/orchestration'
+
+export default defineTask({
+  meta: {
+    name: 'config:ex5',
+    description: 'Exercise 5 - Orchestration Chatbot',
+  },
+  run({ payload }) {
+    const model_name = payload.model as string & ChatModel
+    const result = new OrchestrationClient({
+      llm: { model_name, model_params: { max_tokens: 1000, temperature: 0.2 } },
+      templating: {
+        template: [
+          { role: 'system', content: 'You are a helpful chatbot assistant.' },
+          { role: 'user', content: '{{?user_query}}' },
+        ],
+      },
+      filtering: {
+        input: { filters: [buildAzureContentSafetyFilter()] },
+        output: { filters: [buildAzureContentSafetyFilter()] },
+      },
+      masking: {
+        masking_providers: [
+          buildDpiMaskingProvider({
+            method: 'anonymization',
+            entities: ['profile-person', 'profile-org'],
+          }),
+        ],
+      },
+    })
+    return { result }
+  },
+})


### PR DESCRIPTION
## Summary
- add new Data Masking task
- add advanced Chatbot task combining filtering and masking
- document the new exercises
- explain real-world use cases for each new feature
- describe how exercises fit into the course and link to docs

## Testing
- `pnpm lint` *(fails: Cannot find package `@antfu/eslint-config`)*
- `pnpm typecheck` *(fails: `nuxt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ac77ded88331a5cf91ce4a95a222